### PR TITLE
parse: fix typo

### DIFF
--- a/src/documents/parse/index.html.md
+++ b/src/documents/parse/index.html.md
@@ -83,7 +83,7 @@ signature: `records = parse(text, [options])`
     left-trim all fields). Defaults to `false`. Does not remove whitespace in a
     quoted field.   
 *   `max_limit_on_data_read` (int)   
-    Maximum numer of characters to be contained in the field and line buffers
+    Maximum number of characters to be contained in the field and line buffers
     before an exception is raised. Used to guard against a wrong `delimiter` or
     `rowDelimiter`. Default to 128,000 characters.   
 *   `objname` (string)   

--- a/www/parse/index.html
+++ b/www/parse/index.html
@@ -52,7 +52,7 @@ records will be objects instead of arrays. A value &quot;false&quot; skips the a
 <li><code>ltrim</code> (boolean)<br>If <code>true</code>, ignore whitespace immediately following the delimiter (i.e.
 left-trim all fields). Defaults to <code>false</code>. Does not remove whitespace in a
 quoted field.   </li>
-<li><code>max_limit_on_data_read</code> (int)<br>Maximum numer of characters to be contained in the field and line buffers
+<li><code>max_limit_on_data_read</code> (int)<br>Maximum number of characters to be contained in the field and line buffers
 before an exception is raised. Used to guard against a wrong <code>delimiter</code> or
 <code>rowDelimiter</code>. Default to 128,000 characters.   </li>
 <li><code>objname</code> (string)<br>Name of header-record title to name objects by.   </li>


### PR DESCRIPTION
Fixed a typo in parse documentation