### PR TITLE
Return the actual column value and not the context

### DIFF
--- a/src/md/parse/options/cast.md
+++ b/src/md/parse/options/cast.md
@@ -46,7 +46,7 @@ const records = parse(data, {
     if(context.index === 0){
       return `${value}T05:00:00.000Z`
     }else{
-      return context
+      return value
     }
   },
   trim: true


### PR DESCRIPTION
The cast function must return the value to be used and not the full context with other info.