### PR TITLE
Fix typo in /parse/options/columns

### DIFF
--- a/src/md/parse/options/columns.md
+++ b/src/md/parse/options/columns.md
@@ -48,7 +48,7 @@ parse(`
 
 If the value is an array, to each element corresponds a property. The values may be a string or an object literal with the `name` property.
 
-The [columns example](https://github.com/adaltas/node-csv-parse/blob/master/samples/option.columns.function.js) converts each field of the first to upper case.
+The [columns example](https://github.com/adaltas/node-csv-parse/blob/master/samples/option.columns.array.js) generates record literals whose properties match the values of `columns` option.
 
 ```js
 const parse = require('csv-parse')


### PR DESCRIPTION
This PR fixes description for `csv-parse`'s `columns` options.
Before modification, explanation about function was given in the place where explanation about array should be.

Before:
![image](https://user-images.githubusercontent.com/7571111/53780039-e5ab1a80-3f45-11e9-9cf0-d03517d206da.png)

After:
![image](https://user-images.githubusercontent.com/7571111/53780052-efcd1900-3f45-11e9-999c-28f79e7895c3.png)

I hope this help.