### PR TITLE
Correct typos

### DIFF
--- a/src/md/generate/api.md
+++ b/src/md/generate/api.md
@@ -9,7 +9,7 @@ sort: 2
 
 ## Introduction
 
-There are multiple APIs available. Under the hood, they are all based on the same implementation. The stream API might not be the most pleasant API to use but is scalable. Use the callback style API or the sync API for simplicity, readability and conveniency if you are sure that your datasets fit in memory.
+There are multiple APIs available. Under the hood, they are all based on the same implementation. The stream API might not be the most pleasant API to use but is scalable. Use the callback style API or the sync API for simplicity, readability and convenience if you are sure that your datasets fit in memory.
 
 ## Stream API
 

--- a/src/md/generate/changelog.md
+++ b/src/md/generate/changelog.md
@@ -35,7 +35,7 @@ New features and bug fixes:
 * options: accept snake case and came case keys
 * eof: new option
 * row_delimiter: new option
-* travis: test agains Node.js 11
+* travis: test against Node.js 11
 
 ## Version 2.2.2
 
@@ -67,7 +67,7 @@ New features and bug fixes:
 
 ## Version 2.0.1
 
-* package: es5 backward compatiblity
+* package: es5 backward compatibility
 * package: ignore yarn lock file
 
 ## 2.0.0

--- a/src/md/generate/options.md
+++ b/src/md/generate/options.md
@@ -12,7 +12,7 @@ All options are optional. The [Node.js Stream Writable](https://nodejs.org/api/s
 ## Available options
 
 * `columns` (integer|array|function)   
-  Define the number of generated fields and the generation method. If columns is an integer, it corresponds to the number of fields. If it is an array, each element correspond to a field. If the field is a function, the function is expected to return a value, if a string, it call the registered function of the same name (eg `Generator.int` for the value "int"), current values are "ascii", "int" and "bool", more could be added by the user or on demand by opending a [pull request](https://github.com/adaltas/node-csv-generate/issues/new). Default to 8 ascii columns.
+  Define the number of generated fields and the generation method. If columns is an integer, it corresponds to the number of fields. If it is an array, each element correspond to a field. If the field is a function, the function is expected to return a value, if a string, it call the registered function of the same name (eg `Generator.int` for the value "int"), current values are "ascii", "int" and "bool", more could be added by the user or on demand by opening a [pull request](https://github.com/adaltas/node-csv-generate/issues/new). Default to 8 ascii columns.
 * `delimiter` (string)   
   Set the field delimiter. One or multiple character. Defaults to "," (comma).
 * `duration` (integer)   

--- a/src/md/parse/api.md
+++ b/src/md/parse/api.md
@@ -9,7 +9,7 @@ sort: 2
 
 ## Introduction
 
-There are multiple APIs available. Under the hood, they are all based on the same implementation. The stream API might not be the most pleasant API to use but is scalable. Use the callback style API or the sync API for simplicity, readability and conveniency if you are sure that your datasets fit in memory.
+There are multiple APIs available. Under the hood, they are all based on the same implementation. The stream API might not be the most pleasant API to use but is scalable. Use the callback style API or the sync API for simplicity, readability and convenience if you are sure that your datasets fit in memory.
 
 ## Stream API
 

--- a/src/md/parse/changelog.md
+++ b/src/md/parse/changelog.md
@@ -120,7 +120,7 @@ API management
 * options: extract default options
 * package: add a few keywords
 * src: precompute escapeIsQuote
-* travis: test agains Node.js 11
+* travis: test against Node.js 11
 
 ## Version 3.1.3
 
@@ -200,7 +200,7 @@ Cleanup:
 
 ## Version 2.0.3
 
-* package: es5 backward compatiblity
+* package: es5 backward compatibility
 * package: ignore yarn lock file
 
 ## Version 2.0.2

--- a/src/md/project/getting-started.md
+++ b/src/md/project/getting-started.md
@@ -34,7 +34,7 @@ It means you can either install the `csv` package directly or selectively instal
 
 Installation command is `npm install csv`. If using [Yarn](https://yarnpkg.com/en/), run `yarn add csv`.
 
-The main modules are fully compatible with the Node.js native [stream API](https://nodejs.org/api/stream.html). Alternative API are also provided for conveniency such as the callback, sync and promise APIs.
+The main modules are fully compatible with the Node.js native [stream API](https://nodejs.org/api/stream.html). Alternative API are also provided for convenience such as the callback, sync and promise APIs.
 
 For additional usage and examples, you may refer to
 [the example page](/project/examples/).

--- a/src/md/stringify/api.md
+++ b/src/md/stringify/api.md
@@ -9,7 +9,7 @@ sort: 2
 
 ## Introduction
 
-There are multiple APIs available. Under the hood, they are all based on the same implementation. The stream API might not be the most pleasant API to use but is scalable. Use the callback style API or the sync API for simplicity, readability and conveniency if you are sure that your datasets fit in memory.
+There are multiple APIs available. Under the hood, they are all based on the same implementation. The stream API might not be the most pleasant API to use but is scalable. Use the callback style API or the sync API for simplicity, readability and convenience if you are sure that your datasets fit in memory.
 
 ### Stream API
 

--- a/src/md/stringify/changelog.md
+++ b/src/md/stringify/changelog.md
@@ -75,7 +75,7 @@ Minor enhancements:
 
 Project management:
 * package: update license to MIT
-* travis: test agains Node.js 11
+* travis: test against Node.js 11
 * samples: improve some scripts
 
 ## Version 4.3.1

--- a/src/md/stringify/options/delimiter.md
+++ b/src/md/stringify/options/delimiter.md
@@ -12,7 +12,7 @@ The `delimiter` option set the delimiter between the fields of a record. It can 
 
 ## Default behavior
 
-by default the generated CSV data set will have field value sepated by `,`:
+by default the generated CSV data set will have field value separated by `,`:
 
 ```js
 const stringify = require('csv-stringify')

--- a/src/md/transform/api.md
+++ b/src/md/transform/api.md
@@ -13,13 +13,13 @@ The "csv-transform" package proposes different API flavours available through di
 
 The stream and callback API are exported by the main module, using `require('csv-transform')` or `require('csv').transform`. The sync package is available using `require('csv-transform/lib/sync')` or `require('csv/lib/sync').transform`.
 
-Both modules target ECMAScript Edition 6 (ES6 or ES2015), Node.js version 7.6 and above. For older version of JavaScript, every module is transpiled into ECMAScript Edition 5 (ES5) inside the folder "lib/es5". The ES5 modules share the exact same API with their ES6 counterpart. For exemple, the `sync` module compatible with ES5 is located available using `require('csv-transform/lib/es5/sync')`.
+Both modules target ECMAScript Edition 6 (ES6 or ES2015), Node.js version 7.6 and above. For older version of JavaScript, every module is transpiled into ECMAScript Edition 5 (ES5) inside the folder "lib/es5". The ES5 modules share the exact same API with their ES6 counterpart. For example, the `sync` module compatible with ES5 is located available using `require('csv-transform/lib/es5/sync')`.
 
-The stream API might not be the most pleasant API to use but is scalable. Use the callback style API or the sync API for simplicity, readability and conveniency if you are sure that your datasets fit in memory. Note, it is possible to mix the stream and callback APIs.
+The stream API might not be the most pleasant API to use but is scalable. Use the callback style API or the sync API for simplicity, readability and convenience if you are sure that your datasets fit in memory. Note, it is possible to mix the stream and callback APIs.
 
 ### Node.js Stream API
 
-The main module exporterted by the package is a native Node.js [Transform stream](https://nodejs.org/api/stream.html#stream_class_stream_transform). Transform streams implement both the Readable and Writable interfaces.
+The main module exported by the package is a native Node.js [Transform stream](https://nodejs.org/api/stream.html#stream_class_stream_transform). Transform streams implement both the Readable and Writable interfaces.
 
 This is the recommended approach if you need a maximum of power. It ensures scalability by treating your data as a stream from the source to the destination and support all the options available.
 

--- a/src/md/transform/changelog.md
+++ b/src/md/transform/changelog.md
@@ -9,7 +9,7 @@ sort: 6
 
 ## Trunk
 
-* travis: test agains Node.js 11
+* travis: test against Node.js 11
 
 ## Version 1.0.7
 

--- a/src/md/transform/options.md
+++ b/src/md/transform/options.md
@@ -12,7 +12,7 @@ All options are optional. All the options from the [Node.js Writable Stream API]
 ## Available options
 
 *   `parallel` (number)   
-     The number of transformation callbacks to run in parallel; only appy with asynchronous handlers; default to "100".
+     The number of transformation callbacks to run in parallel; only apply with asynchronous handlers; default to "100".
 *   `consume` (boolean)   
     In the absence of a consumer, like a stream.Readable, trigger the
     consumption of the stream.

--- a/src/pages/convert.js
+++ b/src/pages/convert.js
@@ -26,7 +26,7 @@ class Index extends Component {
       >
         <h1>Convert data between CSV and JSON</h1>
         <p>
-          This is a full-featured CSV parsing tool running entirely on your brower. 
+          This is a full-featured CSV parsing tool running entirely on your browser. 
           No data leave your computer ! 
           Use it also to learn how to use our packages and to test the various options interactively.
         </p>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -151,7 +151,7 @@ class Index extends Component {
           <div>
             <h1><Link to="/convert/"><span>CSV & JSON</span> <span>convertor tool</span></Link></h1>
             <p>
-              This is a full-featured CSV parsing tool running entirely on your brower. 
+              This is a full-featured CSV parsing tool running entirely on your browser. 
               No data leave your computer ! 
               Use it also to learn how to use our packages and to test the various options interactively.
             </p>
@@ -269,7 +269,7 @@ class Index extends Component {
               <Link
                 to="/convert/"
               >
-                Try the new CSV & JSON convertion tool!
+                Try the new CSV & JSON conversion tool!
               </Link>
             </h2>
             <p css={styles.blog_info}>


### PR DESCRIPTION
Noticed this, ran a spell check.

![screenshot_2019-03-13-1047-34](https://user-images.githubusercontent.com/1844746/54302103-7c4a8d80-457d-11e9-9b50-c5e125c18d86.png)