### PR TITLE
Fix stringify stream mode API signature

### DIFF
--- a/src/md/stringify/api.md
+++ b/src/md/stringify/api.md
@@ -13,12 +13,12 @@ There are multiple APIs available. Under the hood, they are all based on the sam
 
 ### Stream API
 
-The main module of the package implements the native Node.js [transform stream][stream] which is both readable and writable.
+The main module of the package implements the native Node.js [transform stream][https://nodejs.org/api/stream.html#stream_object_mode_duplex_streams] which is both readable and writable.
 
 This is the recommended approach if you need a maximum of power. It ensure
 scalability by treating your data as a stream from the source to the destination.
 
-The signature is `const stream = stringify(records, [options])`.
+The signature is `const stream = stringify([options])`.
 
 The [stream example](https://github.com/adaltas/node-csv-stringify/blob/master/samples/api.stream.js) write 2 records and register multiple events to read the generated CSV output and get notified when the serialisation is finished.
 


### PR DESCRIPTION
The original documentation does not match with the [implementation](https://github.com/adaltas/node-csv-stringify/blob/653685fa24615bdc2a6b236b9f2c8c4cbf8092af/lib/index.js#L98), nor does it make sense to have data as an argument for a stream API.

This PR also adds link to nodejs documentation about transform streams (object mode). Feel free to change to the write documentation.