### PR TITLE
(fix) Fix example code for Stream API

### DIFF
--- a/src/md/generate/api.md
+++ b/src/md/generate/api.md
@@ -34,7 +34,7 @@ generate({
 .on('readable', function(){
   let record
   while(record = this.read()){
-    records.push(d)
+    records.push(record)
   }
 })
 .on('error', function(err){


### PR DESCRIPTION
The previous version had `records.push(d)` but `d` is undefined and should read `records.push(record)`