### PR TITLE
Clarify delimiter doc

### DIFF
--- a/src/md/parse/options/delimiter.md
+++ b/src/md/parse/options/delimiter.md
@@ -7,7 +7,7 @@ keywords: ['csv', 'parse', 'options', 'delimiter', 'separator', 'tsv', 'fields',
 
 # Option `delimiter`
 
-It defines the characters used to delimitate the fields inside a record. One or multiple values are accepted. A value can be a string or a Buffer. It can not be empty but it can contains several characters. When not defined, the default value is a comma.
+Defines the character(s) used to delimitate the fields inside a record. A single value or an array of values are accepted. A value can be a string or a Buffer. It can not be empty, and it can contain several characters. When not defined, the default value is a comma.
 
 * Type: `string|Buffer|[string|Buffer]`
 * Optional
@@ -25,12 +25,12 @@ In the [delimiter example](https://github.com/adaltas/node-csv-parse/blob/master
 const parse = require('csv-parse/lib/sync')
 const assert = require('assert')
 
-const data = 'a key => a value'
+const data = 'a key => a value \n b key \t b value'
 const records = parse(data, {
-  delimiter: "=>",
+  delimiter: ["=>", "\t"]
   trim: true
 })
 assert.deepEqual(records, [
-  [ "a key", "a value" ]
+  [ "a key", "a value" ], ["b key", "b value"]
 ])
 ```


### PR DESCRIPTION
Some grammar fixes, reword for clarity, enhanced example to show multiple values being used including an escaped character.

QUESTION: Does the sentence "It is not possible to escape a delimiter" refer to in the data rather than the configuration?  If so, I recommend enhancing that sentence to "It is not possible to escape a delimiter within the data being parsed." (or similar)