### PR TITLE
Add links for "related" options to Available Options (parse & stringify)

### DIFF
--- a/src/md/parse/options/cast.md
+++ b/src/md/parse/options/cast.md
@@ -13,7 +13,7 @@ The `cast` option alter a value. It works at the field level of a record. It is 
 * Optional
 * Default: `undefined`
 * Since: 2.2.0
-* Related: `cast_date`
+* Related: `cast_date`  &mdash; see [Available Options](/parse/options/#available-options)
 
 Its value is expected to be a function which receive a context rich of information. It gives full control over a field. The [`test/option.cast.coffee`](https://github.com/adaltas/node-csv-parse/blob/master/test/option.cast.coffee) test provides insights on how to use it and its supported functionalities.
 

--- a/src/md/parse/options/delimiter.md
+++ b/src/md/parse/options/delimiter.md
@@ -13,7 +13,7 @@ It defines the characters used to delimitate the fields inside a record. One or 
 * Optional
 * Default: `","` (a one character comma)
 * Since: 0.0.1
-* Related: `record_delimiter`, `quote`, `escape`
+* Related: `record_delimiter`, `quote`, `escape`  &mdash; see [Available Options](/parse/options/#available-options)
 
 It is not possible to escape a delimiter. A field must be quoted to ensure the delimiter it contains is not interpreted.
 

--- a/src/md/parse/options/delimiter.md
+++ b/src/md/parse/options/delimiter.md
@@ -7,7 +7,7 @@ keywords: ['csv', 'parse', 'options', 'delimiter', 'separator', 'tsv', 'fields',
 
 # Option `delimiter`
 
-It defines the characters used to delimitate the fields inside a record. One or multiple values are accepted. A value can be a string or a Buffer. It can not be empty but it can contains several characters. When not defined, the default value is a comma.
+Defines the character(s) used to delimitate the fields inside a record. A single value or an array of values are accepted. A value can be a string or a Buffer. It can not be empty, and it can contain several characters. When not defined, the default value is a comma.
 
 * Type: `string|Buffer|[string|Buffer]`
 * Optional
@@ -15,9 +15,9 @@ It defines the characters used to delimitate the fields inside a record. One or 
 * Since: 0.0.1
 * Related: `record_delimiter`, `quote`, `escape`  &mdash; see [Available Options](/parse/options/#available-options)
 
-It is not possible to escape a delimiter. A field must be quoted to ensure the delimiter it contains is not interpreted.
+In the data, it is not possible to escape a delimiter. A field must be quoted to ensure the delimiter value it contains is not interpreted.
 
-# Example
+# Example of single-value delimiter
 
 In the [delimiter example](https://github.com/adaltas/node-csv-parse/blob/master/samples/option.delimiter.js), fields are separated by a two characters delimiter value.
 
@@ -33,4 +33,48 @@ const records = parse(data, {
 assert.deepEqual(records, [
   [ "a key", "a value" ]
 ])
+```
+
+# Example of an array of values
+An example of providing multiple delimiter values for parsing.  Also shows:
+* the `columns` option that is used for naming the fields of each record
+* quoting field values with double quotes to avoid delimiting
+* how trim affects whitespace on values
+
+```js
+const parse = require('csv-parse/lib/sync')
+
+const data = `color name::red::green::blue
+Cyan :: 0 :: 255 :: 255
+"Yellow":: " 255 " \t  "255"  ::"0"
+Hot Pink\t255\t" :: 105"\t180`
+
+const records = parse(data, {
+  delimiter: ["::","\t"],
+  trim: true,
+  columns: true,
+})
+
+records.forEach((rec,index) => {
+  let indent = ""
+  Object.entries(rec).forEach(([key, value]) => {
+    console.log(`${indent}${key}: <${value}>`)
+    indent = (indent.length === 0 ? "    " : indent)
+  })
+})
+
+// Output is:
+//
+//  color name: <Cyan>
+//      red: <0>
+//      green: <255>
+//      blue: <255>
+//  color name: <Yellow>
+//      red: < 255 >
+//      green: <255>
+//      blue: <0>
+//  color name: <Hot Pink>
+//      red: <255>
+//      green: < :: 105>
+//      blue: <180>
 ```

--- a/src/md/parse/options/from_line.md
+++ b/src/md/parse/options/from_line.md
@@ -14,7 +14,7 @@ The `from_line` option handles records starting from a requested line number. Th
 * Optional
 * Default: `1`
 * Since: 4.0.0
-* Related: [`to_line`](/parse/options/to_line/), `from`, `to`
+* Related: [`to_line`](/parse/options/to_line/), `from`, `to`  &mdash; see [Available Options](/parse/options/#available-options)
 
 ## Simple example with inferred column names
 

--- a/src/md/parse/options/to_line.md
+++ b/src/md/parse/options/to_line.md
@@ -14,7 +14,7 @@ The `to_line` option handles records until a requested line number is reached. I
 * Optional
 * Default: `-1`
 * Since: 4.0.0
-* Related: [`from_line`](/parse/options/from_line/), `from`, `to`
+* Related: [`from_line`](/parse/options/from_line/), `from`, `to`  &mdash; see [Available Options](/parse/options/#available-options)
 
 The line matching the value is parsed and the record is including the output. If the record does not end on the line, for example when the new line character is escaped or quoted, it will be disregarded.
 

--- a/src/md/parse/options/trim.md
+++ b/src/md/parse/options/trim.md
@@ -13,7 +13,7 @@ The `trim` option ignore whitespace characters immediately around the [delimiter
 * Optional
 * Default: `false`
 * Since: early days
-* Related: `ltrim`, `rtrim`
+* Related: `ltrim`, `rtrim`  &mdash; see [Available Options](/parse/options/#available-options)
 
 The characters interpreted as whitespaces are identical to the `\s` meta character in regular expressions:
 

--- a/src/md/stringify/options/quoted.md
+++ b/src/md/stringify/options/quoted.md
@@ -13,7 +13,7 @@ Quote all the non-empty fields even when there is no character requiring quotes.
 * Optional
 * Default: `false`
 * Since: 0.0.1
-* Related: [`quoted_empty`](/stringify/options/quoted_empty/), [`quoted_match`](/stringify/options/quoted_match/), [`quoted_string`](/stringify/options/quoted_string/)
+* Related: [`quoted_empty`](/stringify/options/quoted_empty/), [`quoted_match`](/stringify/options/quoted_match/), [`quoted_string`](/stringify/options/quoted_string/)  &mdash; see [Available Options](/stringify/options/#available-options)
 
 Note, several options are available to control when to quote fields under certain conditions. Make sure to review the alternatives.
 

--- a/src/md/stringify/options/quoted_empty.md
+++ b/src/md/stringify/options/quoted_empty.md
@@ -13,7 +13,7 @@ Quote empty strings and overrides `quoted_string` on empty strings when defined.
 * Optional
 * Default: `false`
 * Since: 0.0.4
-* Related: [`quoted_match`](/stringify/options/quoted_match/), [`quoted_string`](/stringify/options/quoted_string/), [`quoted`](/stringify/options/quoted/)
+* Related: [`quoted_match`](/stringify/options/quoted_match/), [`quoted_string`](/stringify/options/quoted_string/), [`quoted`](/stringify/options/quoted/)  &mdash; see [Available Options](/stringify/options/#available-options)
 
 Note, several options are available to control when to quote fields under certain conditions. Make sure to review the alternatives.
 

--- a/src/md/stringify/options/quoted_match.md
+++ b/src/md/stringify/options/quoted_match.md
@@ -13,7 +13,7 @@ Quote all fields matching a regular expression.
 * Optional
 * Default: `false`
 * Since: 5.0.0
-* Related: [`quoted_empty`](/stringify/options/quoted_empty/), [`quoted_string`](/stringify/options/quoted_string/), [`quoted`](/stringify/options/quoted/)
+* Related: [`quoted_empty`](/stringify/options/quoted_empty/), [`quoted_string`](/stringify/options/quoted_string/), [`quoted`](/stringify/options/quoted/)  &mdash; see [Available Options](/stringify/options/#available-options)
 
 Note, several options are available to control when to quote fields under certain conditions. Make sure to review the alternatives.
 

--- a/src/md/stringify/options/quoted_string.md
+++ b/src/md/stringify/options/quoted_string.md
@@ -13,7 +13,7 @@ Quote all fields of type string. This option apply even when there is no charact
 * Optional
 * Default: `false`
 * Since: 0.0.4
-* Related: [`quoted_empty`](/stringify/options/quoted_empty/), [`quoted_match`](/stringify/options/quoted_match/), [`quoted`](/stringify/options/quoted/)
+* Related: [`quoted_empty`](/stringify/options/quoted_empty/), [`quoted_match`](/stringify/options/quoted_match/), [`quoted`](/stringify/options/quoted/)  &mdash; see [Available Options](/stringify/options/#available-options)
 
 Note, several options are available to control when to quote fields under certain conditions. Make sure to review the alternatives.
 


### PR DESCRIPTION
Many of the "Related" options do not have links to their own pages. If you jump straight into the Parse docs (e.g. from a google search) without looking at the rest of the docs, it isn't obvious that "Options" is a detailed page rather than just a section header.