### PR TITLE
Corrected return value for cast option example

### DIFF
--- a/src/md/parse/options/cast.md
+++ b/src/md/parse/options/cast.md
@@ -53,7 +53,7 @@ const records = parse(data, {
     if(context.index === 0){
       return `${value}T05:00:00.000Z`
     }else{
-      return context
+      return value
     }
   },
   trim: true


### PR DESCRIPTION
In the cast option example:
https://csv.js.org/parse/options/cast/

There is the following code:
```js
  cast: function(value, context){
    if(context.index === 0){
      return `${value}T05:00:00.000Z`
    }else{
      return context
    }
  },
```

I am not sure why it is returning `context` - I presume it should be `value`?
But the return value for the cast option function isn't actually explicitly in the documentation.
