### PR TITLE
docs: broken link fixes

### DIFF
--- a/src/md/parse/api.md
+++ b/src/md/parse/api.md
@@ -32,5 +32,5 @@ There are multiple APIs available, each with their own advantages and disadvanta
 For additional usages and examples, you may refer to:
 
 * [the API page](/parse/api/),
-* [the "samples" folder](https://github.com/adaltas/node-csv-parse/tree/master/samples)
-* [the "test" folder](https://github.com/adaltas/node-csv-parse/tree/master/test).
+* [the "samples" folder](https://github.com/adaltas/node-csv/tree/master/packages/csv-parse/samples)
+* [the "test" folder](https://github.com/adaltas/node-csv/tree/master/packages/csv-parse/test).


### PR DESCRIPTION
Broken links of the `"samples"` and `"test"` are fixed in this PR
Closes #79  