### PR TITLE
Fix bug in code sample

### DIFF
--- a/src/md/parse/options/cast.md
+++ b/src/md/parse/options/cast.md
@@ -59,7 +59,7 @@ const records = parse(data, {
       return `${value}T05:00:00.000Z`
     }else{
       // Or the `context` object literal
-      return context
+      return value
     }
   },
   trim: true


### PR DESCRIPTION
function passed to cast, should return value, not context.