### PR TITLE
Update links after monorepo merge

### DIFF
--- a/src/md/generate/examples.md
+++ b/src/md/generate/examples.md
@@ -7,7 +7,7 @@ sort: 5
 
 # CSV Generate examples
 
-This package proposes different API flavours. Every example is available on [GitHub](https://github.com/adaltas/node-csv-generate/tree/master/samples).
+This package proposes different API flavours. Every example is available on [GitHub](https://github.com/adaltas/node-csv/tree/master/packages/csv-generate/samples).
 
 ## Using the pipe function
 

--- a/src/md/generate/index.md
+++ b/src/md/generate/index.md
@@ -15,7 +15,7 @@ This package provides a flexible generator of CSV strings and Javascript objects
 implementing the Node.js `stream.Readable` API. It may be used to generate 
 random or user-defined datasets.
 
-Source code for this project is available on [GitHub](https://github.com/adaltas/node-csv-generate).
+Source code for this project is available on [GitHub](https://github.com/adaltas/node-csv).
 
 ## Main features
 

--- a/src/md/generate/options.md
+++ b/src/md/generate/options.md
@@ -12,7 +12,7 @@ All options are optional. The [Node.js Stream Writable](https://nodejs.org/api/s
 ## Available options
 
 * `columns` (integer|array|function)   
-  Define the number of generated fields and the generation method. If columns is an integer, it corresponds to the number of fields. If it is an array, each element correspond to a field. If the field is a function, the function is expected to return a value, if a string, it call the registered function of the same name (eg `Generator.int` for the value "int"), current values are "ascii", "int" and "bool", more could be added by the user or on demand by opening a [pull request](https://github.com/adaltas/node-csv-generate/issues/new). Default to 8 ascii columns.
+  Define the number of generated fields and the generation method. If columns is an integer, it corresponds to the number of fields. If it is an array, each element correspond to a field. If the field is a function, the function is expected to return a value, if a string, it call the registered function of the same name (eg `Generator.int` for the value "int"), current values are "ascii", "int" and "bool", more could be added by the user or on demand by opening a [pull request](https://github.com/adaltas/node-csv/issues/new). Default to 8 ascii columns.
 * `delimiter` (string)   
   Set the field delimiter. One or multiple character. Defaults to "," (comma).
 * `duration` (integer)   

--- a/src/md/parse/index.md
+++ b/src/md/parse/index.md
@@ -13,7 +13,7 @@ sort: 1
 
 This package is a parser converting CSV text input into arrays or objects. It implements the Node.js [stream API](/parse/api/#stream-api). It also provides alternative APIs for convenience such as the [callback API](/parse/api/#callback-api) and [sync API](/parse/api/#sync-api). It is both extremely easy to use and powerful. It was first released in 2010 and is used against big data sets by a large community.
 
-Source code for this project is available on [GitHub](https://github.com/adaltas/node-csv-parse).
+Source code for this project is available on [GitHub](https://github.com/adaltas/node-csv).
 
 ## Main features
 

--- a/src/md/parse/options/cast.md
+++ b/src/md/parse/options/cast.md
@@ -15,7 +15,7 @@ The `cast` option alter a value. It works at the field level of a record. It is 
 * Since: 2.2.0
 * Related: `cast_date`, [`info`](/parse/options/info/), [`on_record`](/parse/options/on_record/) &mdash; see [Available Options](/parse/options/#available-options)
 
-Its value is expected to be a function which receive a context rich of information. It gives full control over a field. The [`test/option.cast.coffee`](https://github.com/adaltas/node-csv-parse/blob/master/test/option.cast.coffee) test provides insights on how to use it and its supported functionalities.
+Its value is expected to be a function which receive a context rich of information. It gives full control over a field. The [`test/option.cast.coffee`](https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/test/option.cast.coffee) test provides insights on how to use it and its supported functionalities.
 
 ## Context
 

--- a/src/md/project/getting-started.md
+++ b/src/md/project/getting-started.md
@@ -19,16 +19,17 @@ CSV parser and stringifier.
 
 The `csv` package is an umbrella which is itself split into 4 packages:
 
-*   [`csv-generate`](https://github.com/adaltas/node-csv-generate),
+*   [`csv-generate`](https://github.com/adaltas/node-csv/tree/master/packages/csv-generate),
     a flexible generator of CSV string and Javascript objects.
-*   [`csv-parse`](https://github.com/adaltas/node-csv-parse),
+*   [`csv-parse`](https://github.com/adaltas/node-csv/tree/master/packages/csv-parse),
     a parser converting CSV text into arrays or objects.
-*   [`stream-transform`](https://github.com/adaltas/node-stream-transform),
+*   [`stream-transform`](https://github.com/adaltas/node-csv/tree/master/packages/stream-transform),
     a transformation framework.
-*   [`csv-stringify`](https://github.com/adaltas/node-csv-stringify),
+*   [`csv-stringify`](https://github.com/adaltas/node-csv/tree/master/packages/csv-stringify),
     a stringifier converting records into a CSV text.
 
 It means you can either install the `csv` package directly or selectively install one of its child projects to decrease your dependencies.
+Each package's code is versioned under the [Node.js CSV monorepo](https://github.com/adaltas/node-csv).
 
 ## Usage
 

--- a/src/md/stringify/examples.md
+++ b/src/md/stringify/examples.md
@@ -8,7 +8,7 @@ sort: 6
 
 ## Introduction
 
-This package proposes different API flavours. Every example is available on [GitHub](https://github.com/adaltas/node-csv-stringify/tree/master/samples).
+This package proposes different API flavours. Every example is available on [GitHub](https://github.com/adaltas/node-csv/tree/master/packages/csv-stringify/samples).
 
 ## Using the pipe function
 

--- a/src/md/stringify/index.md
+++ b/src/md/stringify/index.md
@@ -42,4 +42,4 @@ For older browsers or older versions of Node, use the modules inside "./lib/es5"
 
 For usage and examples, you may refer to
 [example page](/stringify/examples/),
-[the "samples" folder](https://github.com/adaltas/node-csv-stringify/tree/master/samples) and [the "test" folder](https://github.com/adaltas/node-csv-stringify/tree/master/test).
+[the "samples" folder](https://github.com/adaltas/node-csv/tree/master/packages/csv-stringify/samples) and [the "test" folder](https://github.com/adaltas/node-csv/tree/master/packages/csv-stringify/test).

--- a/src/md/stringify/index.md
+++ b/src/md/stringify/index.md
@@ -15,7 +15,7 @@ callback-based APIs for conveniency. It is both extremely easy to use and
 powerful. It was first released in 2010 and is tested against big data
 sets by a large community.
 
-Source code for this project is available on [GitHub](https://github.com/adaltas/node-csv-stringify).
+Source code for this project is available on [GitHub](https://github.com/adaltas/node-csv).
 
 ## Main features
 

--- a/src/md/stringify/options/columns.md
+++ b/src/md/stringify/options/columns.md
@@ -7,7 +7,7 @@ keywords: ['csv', 'stringify', 'options', 'columns']
 
 # Option `columns`
 
-The associate value with the `column` option may come in different flavours: an int, an array or an object. Consider the [tests](https://github.com/adaltas/node-csv-stringify/blob/master/test/option.columns.coffee) as an exhaustive source of inspiration, examples and supported features.
+The associate value with the `column` option may come in different flavours: an int, an array or an object. Consider the [tests](https://github.com/adaltas/node-csv/blob/master/packages/csv-stringify/test/option.columns.coffee) as an exhaustive source of inspiration, examples and supported features.
 
 Once normalised, the final columns option is an array defining each column. Columns are themselves defined as an object with the properties:
 

--- a/src/md/stringify/options/quoted.md
+++ b/src/md/stringify/options/quoted.md
@@ -19,7 +19,7 @@ Note, several options are available to control when to quote fields under certai
 
 ## Example using "quote"
 
-In the [quoted example](https://github.com/adaltas/node-csv-strinigify/blob/master/samples/option.quoted.js), every field evaluated as empty is not quoted. It includes an empty string and values of `false`, `null` and `undefined`.
+In the [quoted example](https://github.com/adaltas/node-csv/blob/master/packages/csv-strinigify/samples/option.quoted.js), every field evaluated as empty is not quoted. It includes an empty string and values of `false`, `null` and `undefined`.
 
 ```js
 const parse = require('csv-parse')

--- a/src/md/stringify/options/quoted_empty.md
+++ b/src/md/stringify/options/quoted_empty.md
@@ -19,7 +19,7 @@ Note, several options are available to control when to quote fields under certai
 
 ## Example
 
-In the [quoted_empty example](https://github.com/adaltas/node-csv-strinigify/blob/master/samples/option.quoted.js), every field evaluated as empty is quoted. It includes an empty string and values of `false`, `null` and `undefined`.
+In the [quoted_empty example](https://github.com/adaltas/node-csv/blob/master/packages/csv-strinigify/samples/option.quoted.js), every field evaluated as empty is quoted. It includes an empty string and values of `false`, `null` and `undefined`.
 
 ```js
 const stringify = require('../lib')

--- a/src/md/stringify/options/quoted_match.md
+++ b/src/md/stringify/options/quoted_match.md
@@ -19,7 +19,7 @@ Note, several options are available to control when to quote fields under certai
 
 ## Example with a string
 
-In the [quoted_match_string example](https://github.com/adaltas/node-csv-strinigify/blob/master/samples/option.quoted_match_string.js), fields containing the string `"."` are quoted.
+In the [quoted_match_string example](https://github.com/adaltas/node-csv/blob/master/packages/csv-strinigify/samples/option.quoted_match_string.js), fields containing the string `"."` are quoted.
 
 ```js
 const stringify = require('../lib')
@@ -36,7 +36,7 @@ stringify([
 
 ## Example with a regular expression
 
-In the [quoted_match_regexp example](https://github.com/adaltas/node-csv-strinigify/blob/master/samples/option.quoted_match_regexp.js), fields matching the regular expression `/\./` are quoted.
+In the [quoted_match_regexp example](https://github.com/adaltas/node-csv/blob/master/packages/csv-strinigify/samples/option.quoted_match_regexp.js), fields matching the regular expression `/\./` are quoted.
 
 ```js
 const stringify = require('../lib')

--- a/src/md/stringify/options/quoted_string.md
+++ b/src/md/stringify/options/quoted_string.md
@@ -19,7 +19,7 @@ Note, several options are available to control when to quote fields under certai
 
 ## Example
 
-The [quoted_string example](https://github.com/adaltas/node-csv-strinigify/blob/master/samples/option.quoted.js) illustrates that only fields of type `string`, empty or not, are quoted.
+The [quoted_string example](https://github.com/adaltas/node-csv/blob/master/packages/csv-stringify/samples/option.quoted.js) illustrates that only fields of type `string`, empty or not, are quoted.
 
 ```js
 const parse = require('csv-parse')

--- a/src/md/transform/examples.md
+++ b/src/md/transform/examples.md
@@ -16,7 +16,7 @@ For additional usages and examples, you may refer to:
 
 ## Mixing the stream and callback APIs
 
-The [output stream example](https://github.com/adaltas/node-csv/blob/master/packages/stream-transform/samples/mixed.string_input.js) send the data in the form of a string and read the resulted dataset as a stream.
+The [output stream example](https://github.com/adaltas/node-csv/blob/master/packages/stream-transform/samples/mixed.output_stream.js) send the data in the form of a string and read the resulted dataset as a stream.
 
 ```js
 const transform = require('stream-transform')

--- a/src/md/transform/index.md
+++ b/src/md/transform/index.md
@@ -13,7 +13,7 @@ sort: 1
 
 This project provides a simple object transformation framework implementing the Node.js `stream.Transform` API. Transformations are based on a [user function](/transform/user_function/) which must be provided. It was originally developed as a part of the Node.js [CSV package](https://github.com/adaltas/node-csv) (`npm install csv`) and can be used independently.
 
-Source code for this project is available on [GitHub](https://github.com/adaltas/node-stream-transform).
+Source code for this project is available on [GitHub](https://github.com/adaltas/node-csv).
 
 ## Main features
 


### PR DESCRIPTION
hello, I'm not sure what's the status on #85 but I believe I updated all the old links in this PR (both to examples and repositories)

also, if you still use travis-ci it doesn't seem like https://travis-ci.org/#!/adaltas/node-csv-parse or https://travis-ci.org/#!/adaltas/node-csv point to the pages they should? (The badges still show up green in any case)