### PR TITLE
Fix type on quoted_match doc page

### DIFF
--- a/src/md/stringify/options/quoted_match.md
+++ b/src/md/stringify/options/quoted_match.md
@@ -9,7 +9,7 @@ keywords: ['csv', 'stringify', 'options', 'quotes', 'delimiter', 'escape']
 
 Quote all fields matching a regular expression.
 
-* Type: `boolean`
+* Type: `String|RegExp`
 * Optional
 * Default: `false`
 * Since: 5.0.0


### PR DESCRIPTION
This PR updates the `quoted_match` doc page to use the `String|RegExp` type instead of `boolean`.  This makes the page match what's documented on https://csv.js.org/stringify/options/ for that setting, as well as how it's used in the examples.