### PR TITLE
Mention "string" cast parameter in options.md

### DIFF
--- a/src/md/stringify/options.md
+++ b/src/md/stringify/options.md
@@ -25,6 +25,8 @@ All options are optional. All the options from the [Node.js Writable Stream API]
     Custom function to transform number values.
   * `object`
     Custom function to transform object literals.
+  * `string`
+    Custom function to transform string values.
 * [`columns`](/stringify/options/columns/) (array|object)   
   _Since version 0.0.1_   
   Influence the generation of records at the field level.


### PR DESCRIPTION
In the main Options page of the stringify docs, the `string` parameter is missing, as you can see it [here](https://csv.js.org/stringify/options/).
<img width="881" alt="image" src="https://user-images.githubusercontent.com/16478013/172438752-5b404503-6457-43f4-947b-91dae5741539.png">
