### PR TITLE
docs: update dead URL.

### DIFF
--- a/src/md/parse/index.md
+++ b/src/md/parse/index.md
@@ -38,5 +38,5 @@ For older browsers or older versions of Node, use the modules inside "./lib/es5"
 ## Additional help
 
 For usage and examples, you may refer to
-[example page](/parse/examples/),
+[example page](/project/examples/),
 [the "samples" folder](https://github.com/adaltas/node-csv/tree/master/packages/csv-parse/samples) and [the "test" folder](https://github.com/adaltas/node-csv/tree/master/packages/csv-parse/test).

--- a/src/md/parse/index.md
+++ b/src/md/parse/index.md
@@ -38,5 +38,5 @@ For older browsers or older versions of Node, use the modules inside "./lib/es5"
 ## Additional help
 
 For usage and examples, you may refer to
-[example page](/project/examples/),
+[recipes page](/parse/recipes/),
 [the "samples" folder](https://github.com/adaltas/node-csv/tree/master/packages/csv-parse/samples) and [the "test" folder](https://github.com/adaltas/node-csv/tree/master/packages/csv-parse/test).


### PR DESCRIPTION
Note: there are no /parse/examples/ folder for csv-parse.  There is project folder /project/examples/ which features parse examples.  Other sub folders have Example section; but not the csv-parse section.