### PR TITLE
docs: update dead URL

### DIFF
--- a/src/md/stringify/examples.md
+++ b/src/md/stringify/examples.md
@@ -8,7 +8,7 @@ sort: 5
 
 ## Introduction
 
-This package proposes different API flavors. Every example is available on [GitHub](https://github.com/adaltas/node-csv-stringify/tree/master/samples).
+This package proposes different API flavors. Every example is available on [GitHub](https://github.com/adaltas/node-csv/tree/master/packages/csv-stringify/samples).
 
 ## Using the pipe function
 


### PR DESCRIPTION
Notes: https://github.com/adaltas/node-csv-stringify/tree/master/samples references dead URL. node-csv-stringify was merged into monorepo. Update Github URL reference.