### PR TITLE
Improve menu UX

### DIFF
--- a/src/layout/Menu.js
+++ b/src/layout/Menu.js
@@ -23,6 +23,7 @@ const styles_nav = {
     '& > ul': {
       margin: '0',
       paddingTop: '0',
+      marginLeft: '.5rem',
       boxSizing: 'border-box',
       overflow: 'hidden',
       height: '0',

--- a/src/layout/Menu.js
+++ b/src/layout/Menu.js
@@ -106,8 +106,8 @@ const styles_nav = {
     transition: 'transform .5s ease-out',
   },
   icon_down: {
-    transform: 'rotate(0deg)',
-  }
+    transform: 'rotate(90deg)',
+  },
 }
 
 const List1 = ({
@@ -181,7 +181,7 @@ const Nav = ({
         ripple={true}
         className={css(styles_nav.button).toString()}
       >
-        <svg css={[styles_nav.icon, current ? styles_nav.icon_down : styles_nav.icon_up]}>
+        <svg css={[styles_nav.icon, current ? styles_nav.icon_up : styles_nav.icon_down]}>
           <polygon points="8,14.124,1,2,15,2" fill="none" stroke="rgb(179,198,200)"/>
         </svg>
       </Icon>

--- a/src/layout/Menu.js
+++ b/src/layout/Menu.js
@@ -6,10 +6,11 @@ import Icon from '../components/Icon'
 const styles_nav = {
   root: {
     fontWeight: '300',
+    marginTop: '2rem',
     '& h1': {
       fontSize: '1.2rem',
       fontWeight: '300',
-      margin: '2rem 0 0 0',
+      margin: 0,
       padding: '0 1rem',
       display: 'flex',
       cursor: 'pointer',
@@ -23,7 +24,6 @@ const styles_nav = {
     '& > ul': {
       margin: '0',
       paddingTop: '0',
-      marginLeft: '.5rem',
       boxSizing: 'border-box',
       overflow: 'hidden',
       height: '0',
@@ -61,7 +61,11 @@ const styles_nav = {
     },
   },
   current: {
+    backgroundColor: 'rgba(255, 255, 255, .05)',
+    borderTop: '1px solid rgba(255, 255, 255, .1)',
+    borderBottom: '1px solid rgba(255, 255, 255, .1)',
     '& h1': {
+      paddingTop: '1rem',
       cursor: 'default',
       ':hover button': {
         backgroundColor: 'rgba(255, 255, 255, 0)',
@@ -70,6 +74,7 @@ const styles_nav = {
     '& > ul': {
       // display: '',
       paddingTop: '1rem',
+      paddingBottom: '1rem',
       overflow: 'visible',
       height: 'auto',
       opacity: '1',

--- a/src/layout/Menu.js
+++ b/src/layout/Menu.js
@@ -179,9 +179,8 @@ const Nav = ({
         color="inherit"
         ripple={true}
         className={css(styles_nav.button).toString()}
-        disabled={current}
       >
-        <svg css={[styles_nav.icon, current ? styles_nav.icon_up : styles_nav.icon_down]}>
+        <svg css={[styles_nav.icon, current ? styles_nav.icon_down : styles_nav.icon_up]}>
           <polygon points="8,14.124,1,2,15,2" fill="none" stroke="rgb(179,198,200)"/>
         </svg>
       </Icon>
@@ -238,7 +237,11 @@ const Menu = ({
   const defaultSlug = extractMenuSlug(slug)
   const [currentSlug, setCurrentSlug] = useState(defaultSlug)
   const onToggle = (slug) => {
+    if(currentSlug === extractMenuSlug(slug)) {
+      setCurrentSlug(undefined)
+    } else {
     setCurrentSlug(extractMenuSlug(slug))
+    }
   }
   let menus = { children: {
     project: {

--- a/src/layout/Menu.js
+++ b/src/layout/Menu.js
@@ -180,6 +180,7 @@ const Nav = ({
         color="inherit"
         ripple={true}
         className={css(styles_nav.button).toString()}
+        // disabled={current}
       >
         <svg css={[styles_nav.icon, current ? styles_nav.icon_up : styles_nav.icon_down]}>
           <polygon points="8,14.124,1,2,15,2" fill="none" stroke="rgb(179,198,200)"/>
@@ -241,7 +242,7 @@ const Menu = ({
     if(currentSlug === extractMenuSlug(slug)) {
       setCurrentSlug(undefined)
     } else {
-    setCurrentSlug(extractMenuSlug(slug))
+      setCurrentSlug(extractMenuSlug(slug))
     }
   }
   let menus = { children: {


### PR DESCRIPTION
The menu is quite confusing and hard to navigate. This PR aims at improving the menu UX:
- the collapse Icon indicator made it look expanded when collapsed and vice versa. I switched the icons.
- the expanded item can now be closed.
- I added a small margin left to menu items to clearly show the parent-child relationship
