### PR TITLE
Clarify Node version support for `csv-parse/sync`

### DIFF
--- a/src/md/parse/distributions/nodejs_cjs.md
+++ b/src/md/parse/distributions/nodejs_cjs.md
@@ -21,7 +21,7 @@ The CommonJS distribution of this package supports the usage of Node.js version 
 
 Internally, the [`export` property](https://nodejs.org/api/packages.html#packages_exports) inside the `package.json` file declares the `csv-parse` and `csv-parse/sync` entry points. It exposes the modules of the [`./dist/cjs` folder](https://github.com/adaltas/node-csv/tree/master/packages/csv-parse/lib).
 
-It is supported in Node.js 12+ as an alternative to the `main` field. For older version, the `main` field behave as a fallback of the `csv` module. It is transparent. Use `require("csv/dist/cjs/sync.cjs")` as an alternative to `require("csv/sync")`.
+It is supported in Node.js 12.16.0+ as an alternative to the `main` field. For older versions, the `main` field behaves as a fallback to the `csv` module. It is transparent. Use `require("csv-parse/dist/cjs/sync.cjs")` as an alternative to `require("csv-parse/sync")`.
 
 ## Older versions of this package
 


### PR DESCRIPTION
[Conditional exports](https://nodejs.org/api/packages.html#conditional-exports) were introduced in Node 12.16.0. As a result, the following code will not work in versions below that. 

```js
const { parse } = require("csv-parse/sync");
```

For versions below 12.16.0, you need to do:

```js
const { parse } = require("csv-parse/dist/cjs/sync.cjs");
```

I discovered this when I attempted to use the first version in Node 12.14.1. 

## Testing
1. Install [`nvm`](https://github.com/nvm-sh/nvm/blob/master/README.md#install--update-script) and `nvm use 12.14.1`. 
2. Create a new file and add: 
```js
const { parse } = require("csv-parse/sync");
console.log(parse);
```
3. Run the file. You should get an error like: 
```sh
internal/modules/cjs/loader.js:796
    throw err;
    ^

Error: Cannot find module 'csv-parse/sync'
Require stack:
- /Users/salomonebaquis/Desktop/csv-parse-test/main.js
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:793:17)
    at Function.Module._load (internal/modules/cjs/loader.js:686:27)
    at Module.require (internal/modules/cjs/loader.js:848:19)
    at require (internal/modules/cjs/helpers.js:74:18)
    at Object.<anonymous> (/Users/salomonebaquis/Desktop/csv-parse-test/main.js:3:19)
    at Module._compile (internal/modules/cjs/loader.js:955:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:991:10)
    at Module.load (internal/modules/cjs/loader.js:811:32)
    at Function.Module._load (internal/modules/cjs/loader.js:723:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1043:10) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [ '/Users/salomonebaquis/Desktop/csv-parse-test/main.js' ]
}
```
4. Replace the require with `const { parse } = require("csv-parse/dist/cjs/sync.cjs");` and run the file again. This should log the correct sync function. 

