### PR TITLE
fix: correct typos in documentation and component names

### DIFF
--- a/src/layout/Menu.js
+++ b/src/layout/Menu.js
@@ -248,7 +248,7 @@ const Menu = ({ onClickLink, pages, slug }) => {
           },
           convert: {
             slug: '/convert/',
-            title: 'Convertor',
+            title: 'Converter',
             sort: 2,
           },
         },
@@ -295,7 +295,7 @@ const Menu = ({ onClickLink, pages, slug }) => {
       }
     })
   })
-  // Sort hierachy, result is made of nested arrays
+  // Sort hierarchy, result is made of nested arrays
   const sort = (pages) => {
     return Object.keys(pages)
       .map((name) => {

--- a/src/md/generate/distributions.md
+++ b/src/md/generate/distributions.md
@@ -18,7 +18,7 @@ sort: 2
 
 # Available distributions
 
-The library is packaged into multiple distributions depending on your Node.js version, you browser environnement and wether you are using ECMAScript modules (ESM), CommonJS or vanilla JavaScript with support for older browser.
+The library is packaged into multiple distributions depending on your Node.js version, your browser environment and whether you are using ECMAScript modules (ESM), CommonJS or vanilla JavaScript with support for older browser.
 
 - [Node.js ECMAScript modules (ESM)](/generate/distributions/nodejs_esm/)
 - [Node.js CommonJS (CJS)](/generate/distributions/nodejs_cjs/)

--- a/src/md/parse/distributions.md
+++ b/src/md/parse/distributions.md
@@ -18,7 +18,7 @@ sort: 2
 
 # Available distributions
 
-The library is packaged into multiple distributions depending on your Node.js version, you browser environnement and wether you are using ECMAScript modules (ESM), CommonJS or vanilla JavaScript with support for older browser.
+The library is packaged into multiple distributions depending on your Node.js version, your browser environment and whether you are using ECMAScript modules (ESM), CommonJS or vanilla JavaScript with support for older browser.
 
 - [Node.js ECMAScript modules (ESM)](/parse/distributions/nodejs_esm/)
 - [Node.js CommonJS (CJS)](/parse/distributions/nodejs_cjs/)

--- a/src/md/parse/info.md
+++ b/src/md/parse/info.md
@@ -23,7 +23,7 @@ They are available in the `info` object of a parser instance and are also export
 - `bytes_records` (number)  
   Number of processed bytes until the last successfully parsed and emitted records.
 - `columns` (boolean || object)  
-  Normalized verion of `options.columns`.
+  Normalized version of `options.columns`.
 - `comment_lines` (number)  
   Count the number of lines being fully commented.
 - `empty_lines` (number)  
@@ -37,12 +37,12 @@ They are available in the `info` object of a parser instance and are also export
 
 ## Record information
 
-It is exposed with the [`info` option](/parse/options/info/) and the [`on_record` option](/parse/options/on_record/). Refers to their respective documentation to learn their usage as well as any additionnal properties they might expose.
+It is exposed with the [`info` option](/parse/options/info/) and the [`on_record` option](/parse/options/on_record/). Refers to their respective documentation to learn their usage as well as any additional properties they might expose.
 
-It contains all the dataset information with additionnal properties:
+It contains all the dataset information with additional properties:
 
 - `error` (Error)  
-  The error that was encountered, useful with the variuos relax options.
+  The error that was encountered, useful with the various relax options.
 - `header` (boolean)  
   True when the [`columns` option](/parse/options/columns/) is activated and the current record is interpreted as a header instead of a data record.
 - `index` (number)  
@@ -52,9 +52,9 @@ It contains all the dataset information with additionnal properties:
 
 It is exposed by the [`cast` option](/parse/options/cast/) and [`cast_date` option](/parse/options/cast_date/) when defined as functions.
 
-Runtime errors are enriched with the field information as well as some additionnal properties when appropriate.
+Runtime errors are enriched with the field information as well as some additional properties when appropriate.
 
-It contains all the dataset and record information with additionnal properties:
+It contains all the dataset and record information with additional properties:
 
 - `column` (string || index)  
   The column name if the `columns` option is active or the field index position in the record.

--- a/src/md/parse/options/cast_date.md
+++ b/src/md/parse/options/cast_date.md
@@ -31,6 +31,6 @@ This option was named `auto_parse_date` until version 2.
 
 ## Usage
 
-When active [`cast_date` with `true`](https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/samples/option.cast_date.js), every field is tested with `Date.parse`. When the convertion to a JavaScript date succeed, the new date is returned. Otherwise, the original value is returned.
+When active [`cast_date` with `true`](https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/samples/option.cast_date.js), every field is tested with `Date.parse`. When the conversion to a JavaScript date succeed, the new date is returned. Otherwise, the original value is returned.
 
 `embed:packages/csv-parse/samples/option.cast_date.js`

--- a/src/md/parse/options/comment.md
+++ b/src/md/parse/options/comment.md
@@ -19,12 +19,12 @@ Treat all the characters after this one as a comment. It can be made of one or m
 - Default: `""`
 - Since: early days
 
-The escape sequence can be defined at the begining of record (a line if the record delimiter is a line return) or anywhere else. Every characters found after the escape sequence will be disregarded.
+The escape sequence can be defined at the beginning of record (a line if the record delimiter is a line return) or anywhere else. Every characters found after the escape sequence will be disregarded.
 
 Escaping is disabled inside a quoted field. The escape sequence will be preserved like any other bytes. It cannot be escaped.
 
 # Example
 
-The [comment example](https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/samples/option.comment.js) insert two comments, one at the begining of the file and another one after a record.
+The [comment example](https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/samples/option.comment.js) insert two comments, one at the beginning of the file and another one after a record.
 
 `embed:packages/csv-parse/samples/option.comment.js`

--- a/src/md/parse/options/encoding.md
+++ b/src/md/parse/options/encoding.md
@@ -35,19 +35,19 @@ The list of [available supported encoding in Node.js](https://github.com/nodejs/
 
 The default encoding in Node.js is UTF-8. When using UTF-8, you do not need to specify anything.
 
-When an alternative encoding is used, it can be discovered with the [BOM](/parse/options/bom/) (byte order mark) present at the begining of the input data or it can be defined with this option.
+When an alternative encoding is used, it can be discovered with the [BOM](/parse/options/bom/) (byte order mark) present at the beginning of the input data or it can be defined with this option.
 
 ## Working with options
 
 When providing options, the values must internally reflect the data source encoding. If the value is a string, the parser will convert the value into a buffer representation using the selected encoding input value.
 
-However, if the value is a buffer, you must make sure the buffer was created with the right encoding, here is an exemple [encoding an option as buffer](https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/samples/option.encoding.options.js), the `delimiter` option in this case:
+However, if the value is a buffer, you must make sure the buffer was created with the right encoding, here is an example [encoding an option as buffer](https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/samples/option.encoding.options.js), the `delimiter` option in this case:
 
 `embed:packages/csv-parse/samples/option.encoding.options.js`
 
 ## Bom automatic detection
 
-The BOM is a special Unicode character sequence at the begining of a text stream to indicate the encoding.
+The BOM is a special Unicode character sequence at the beginning of a text stream to indicate the encoding.
 
 Because the BOM is specific to unicode, only the UTF-8 and UTF-16LE encoding are natively detected by the parser. Here is an example [detecting the encoding](https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/samples/option.encoding.detection.js), UTF-16LE in this case:
 

--- a/src/md/parse/options/escape.md
+++ b/src/md/parse/options/escape.md
@@ -1,7 +1,7 @@
 ---
 title: Option escape
 navtitle: escape
-description: Option "escape" to escape quote and escape characters inside quoted fileds.
+description: Option "escape" to escape quote and escape characters inside quoted fields.
 keywords:
   - csv
   - parse

--- a/src/md/parse/options/ignore_last_delimiters.md
+++ b/src/md/parse/options/ignore_last_delimiters.md
@@ -35,6 +35,6 @@ and here:
 
 ## Example
 
-In this [example](/https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/samples/option.ignore_last_delimiters.js), the CSV data is made of 2 fields, `format` and `description`. Fields are separated by commans, the default [delimiter](/parse/options/delimiter/). The last field, `description`, can contains any number of commas without breaking the record.
+In this [example](/https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/samples/option.ignore_last_delimiters.js), the CSV data is made of 2 fields, `format` and `description`. Fields are separated by commas, the default [delimiter](/parse/options/delimiter/). The last field, `description`, can contains any number of commas without breaking the record.
 
 `embed:packages/csv-parse/samples/option.ignore_last_delimiters.js`

--- a/src/md/parse/options/info.md
+++ b/src/md/parse/options/info.md
@@ -14,7 +14,7 @@ keywords:
 
 # Option `info`
 
-The `info` option provide additionnal context. Instead of generating records, in the form of objects literal or arrays, it generates two properties, `info` and `record`. The `info` property is a snapshot of the [info object](/parse/info/) at the time the record was created. The `record` property is the actual record.
+The `info` option provide additional context. Instead of generating records, in the form of objects literal or arrays, it generates two properties, `info` and `record`. The `info` property is a snapshot of the [info object](/parse/info/) at the time the record was created. The `record` property is the actual record.
 
 Note, it can be used conjointly with the raw option.
 

--- a/src/md/parse/options/objname.md
+++ b/src/md/parse/options/objname.md
@@ -39,6 +39,6 @@ Below, [the `objname` option is a string](https://github.com/adaltas/node-csv/bl
 
 Index names reference a record field by its position. Thus, records must be generated as arrays.
 
-Below, [the `objname` option is a number](https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/samples/option.objname.index.js) and it defined the field in the second postion at index `1`:
+Below, [the `objname` option is a number](https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/samples/option.objname.index.js) and it defined the field in the second position at index `1`:
 
 `embed:packages/csv-parse/samples/option.objname.index.js`

--- a/src/md/parse/options/relax_column_count.md
+++ b/src/md/parse/options/relax_column_count.md
@@ -22,7 +22,7 @@ Note, this option is completed by the [`relax_column_count_less` option](/parse/
 - Since: 1.0.6
 - Related: [`relax_column_count_less`](/parse/options/relax_column_count_less/), `quote`, [`relax_column_count_more`](/parse/options/relax_column_count_more/) &mdash; see [Available Options](/parse/options/#available-options)
 
-The option can be used conjointly with the `columns` option. The expected number of fields is determined by the length of the `columns` option, wether it is defined by the user or dynamically discovered.
+The option can be used conjointly with the `columns` option. The expected number of fields is determined by the length of the `columns` option, whether it is defined by the user or dynamically discovered.
 
 ## Default behavior
 
@@ -38,7 +38,7 @@ When using the `columns` option, the records are generated as objects whose prop
 
 ## Handling inconsistent number of fields errors
 
-When used conjointly with other options, it is possible to accept inconsistent records and provide you own parsing implementation. For exemple, the [`on_record`](/parse/options/on_record/) option let you insert your custom code. If needed, the [`raw`](/parse/options/raw/) option expose the raw record. Finally, the full error is available including the error code.
+When used conjointly with other options, it is possible to accept inconsistent records and provide you own parsing implementation. For example, the [`on_record`](/parse/options/on_record/) option let you insert your custom code. If needed, the [`raw`](/parse/options/raw/) option expose the raw record. Finally, the full error is available including the error code.
 
 This is an example to [handle inconsistent record field lengths](https://github.com/adaltas/node-csv/blob/master/packages/csv-parse/samples/option.relax_column_count.record_inconsistent_length.js).
 

--- a/src/md/project/api.md
+++ b/src/md/project/api.md
@@ -14,7 +14,7 @@ There are multiple APIs and styles available, each with their own advantages and
 * [Stream API](/parse/api/stream/)   
   The stream API might not be the most pleasant API to use but is scalable.
 * [Callback API](/parse/api/callback/)   
-  The callback API buffers all the emitted data from the stream API into a single object which is passed to a user provided function. Passing a function is easier than implementing the stream events function but it implies that the all dataset must fit into the available memory and it will only be available after the last record has been processed. This is usually not recommanded, use the Sync API instead.
+  The callback API buffers all the emitted data from the stream API into a single object which is passed to a user provided function. Passing a function is easier than implementing the stream events function but it implies that the all dataset must fit into the available memory and it will only be available after the last record has been processed. This is usually not recommended, use the Sync API instead.
   
 For additional usages and examples, you may refer to:
 

--- a/src/md/project/api/stream.md
+++ b/src/md/project/api/stream.md
@@ -11,7 +11,7 @@ The Node.js stream API is scalable and offers the greatest control over the data
 
 ## Using the pipe API
 
-Pipes in Node.js is a native functionnality provided by the [stream API](https://nodejs.org/api/stream.html). It behave just like Unix pipes where the output of a process, here a stream reader, is redirected as the input of the following process, here a stream writer.
+Pipes in Node.js is a native functionality provided by the [stream API](https://nodejs.org/api/stream.html). It behave just like Unix pipes where the output of a process, here a stream reader, is redirected as the input of the following process, here a stream writer.
 
 The [pipe example](https://github.com/adaltas/node-csv/blob/master/packages/csv/samples/pipe.js) is quite readable while also scalable:
 

--- a/src/md/project/contribute.md
+++ b/src/md/project/contribute.md
@@ -28,7 +28,7 @@ The project is developed and maintained by [Adaltas](https://www.adaltas.com), a
 
 ## Contributors
 
-Bellow is a non-restrictive list of contributors:
+Below is a non-restrictive list of contributors:
 
 *   David Worms: <https://github.com/adaltas>
 *   Will White: <https://github.com/willwhite>

--- a/src/md/project/distributions.md
+++ b/src/md/project/distributions.md
@@ -17,7 +17,7 @@ sort: 4
 
 # Available distributions
 
-Each package of the `csv` project is packaged into multiple distributions depending on your Node.js version, you browser environnement and wether you are using ECMAScript modules (ESM), CommonJS or vanilla JavaScript with support for older browser.
+Each package of the `csv` project is packaged into multiple distributions depending on your Node.js version, your browser environment and whether you are using ECMAScript modules (ESM), CommonJS or vanilla JavaScript with support for older browser.
 
 - [Node.js ECMAScript modules (ESM)](/project/distributions/nodejs_esm/)
 - [Node.js CommonJS (CJS)](/project/distributions/nodejs_cjs/)

--- a/src/md/project/distributions/browser_esm.md
+++ b/src/md/project/distributions/browser_esm.md
@@ -23,7 +23,7 @@ The ESM distribution target the latest browsers with support for [ECMAScript mod
 
 Compared with the [Node.js version](/csv/distributions/nodejs_esm/), this distribution bundles polyfills to run outside of the Node.js environment.
 
-Modern web browsers import ECMAScript modules nativelly and it also works within webpack and other alternative bundlers. Two demonstrations are available:
+Modern web browsers import ECMAScript modules natively and it also works within webpack and other alternative bundlers. Two demonstrations are available:
 
 - A Vanilla Javascript application with [Express](https://expressjs.com/) targeting web browsers with module support.
 - A web application bundled with [webpack](https://webpack.js.org/).

--- a/src/md/project/distributions/nodejs_cjs.md
+++ b/src/md/project/distributions/nodejs_cjs.md
@@ -10,7 +10,7 @@ sort: 4.2
 
 The CommonJS distribution is appropriate to Node.js packages which have not yet migrated to [ECMAScript modules](/project/distributions/nodejs_esm/).
 
-Node.js builtin globals and modules are not inserted. This is both motivated by performance and compatiblity reasons. The buffer shim generates error, [see #303](https://github.com/adaltas/node-csv/issues/303). Use the [browser IIFE distribution](/project/distributions/browser_iife/) or integrate the module with a build system to provide the appropriate shims.
+Node.js builtin globals and modules are not inserted. This is both motivated by performance and compatibility reasons. The buffer shim generates error, [see #303](https://github.com/adaltas/node-csv/issues/303). Use the [browser IIFE distribution](/project/distributions/browser_iife/) or integrate the module with a build system to provide the appropriate shims.
 
 When using the `csv` package, use the following import directives:
 

--- a/src/md/stringify/api.md
+++ b/src/md/stringify/api.md
@@ -16,7 +16,7 @@ There are multiple APIs available, each with their own advantages and disadvanta
 * [Stream API](/stringify/api/stream/)   
   The stream API might not be the most pleasant API to use but is scalable.
 * [Callback API](/stringify/api/callback/)   
-  The callback API buffers all the emitted records from the stream API into a single array which is passed to a user provided function. Passing a function is easier than implementing the stream events function but it implies that the all dataset must fit into the available memory and it will only be available after the last record has been processed. This is usually not recommanded, use the Sync API instead.
+  The callback API buffers all the emitted records from the stream API into a single array which is passed to a user provided function. Passing a function is easier than implementing the stream events function but it implies that the all dataset must fit into the available memory and it will only be available after the last record has been processed. This is usually not recommended, use the Sync API instead.
 * [Stream API + dataset](/stringify/api/stream_callback/)  
   Replace the writable stream with records or the readable stream with a callback function.
 * [Async iterator API](/stringify/api/async_iterator/)   

--- a/src/md/stringify/distributions.md
+++ b/src/md/stringify/distributions.md
@@ -18,7 +18,7 @@ sort: 2
 
 # Available distributions
 
-The library is packaged into multiple distributions depending on your Node.js version, you browser environnement and wether you are using ECMAScript modules (ESM), CommonJS or vanilla JavaScript with support for older browser.
+The library is packaged into multiple distributions depending on your Node.js version, your browser environment and whether you are using ECMAScript modules (ESM), CommonJS or vanilla JavaScript with support for older browser.
 
 - [Node.js ECMAScript modules (ESM)](/stringify/distributions/nodejs_esm/)
 - [Node.js CommonJS (CJS)](/stringify/distributions/nodejs_cjs/)

--- a/src/md/stringify/options/eof.md
+++ b/src/md/stringify/options/eof.md
@@ -17,7 +17,7 @@ The `eof` option append the value of the `record_delimiter` option after the las
 
 ## Default behavior
 
-By default, the `eof` option is [enabled](https://github.com/adaltas/node-csv/blob/master/packages/csv-stringify/samples/option.eof_true.js). Not defining its value is equivelent set seting `eof` as `true`:
+By default, the `eof` option is [enabled](https://github.com/adaltas/node-csv/blob/master/packages/csv-stringify/samples/option.eof_true.js). Not defining its value is equivalent to setting `eof` as `true`:
 
 `embed:packages/csv-stringify/samples/option.eof_true.js`
 

--- a/src/md/stringify/options/escape_formulas.md
+++ b/src/md/stringify/options/escape_formulas.md
@@ -17,6 +17,6 @@ Escape values that start with `=`, `+`, `-`, `@`, `\t`, or `\r` with `'` and def
 
 ## Example
 
-In the [escape formulas example](https://github.com/adaltas/node-csv/tree/master/packages/csv-stringify/samples/option.escape_formulas.js), every field wich starts with the values `=` and `@` is escaped by prefixing its value with `'`.
+In the [escape formulas example](https://github.com/adaltas/node-csv/tree/master/packages/csv-stringify/samples/option.escape_formulas.js), every field which starts with the values `=` and `@` is escaped by prefixing its value with `'`.
 
 `embed:packages/csv-stringify/samples/option.escape_formulas.js`

--- a/src/md/transform/api.md
+++ b/src/md/transform/api.md
@@ -12,13 +12,13 @@ This package proposes different API flavors available through different modules.
 * [Sync API](/transform/api/sync/)   
   The sync API provides simplicity, readability and convenience. However, both the input and output datasets must fit into memory and only synchronous handlers are supported.
 * [Stream API](/transform/api/stream/)   
-  The stream API is scalable and is the default implemention upon witch other API are created. It is verbose but flexible.
+  The stream API is scalable and is the default implementation upon which other API are created. It is verbose but flexible.
 * [Callback API](/transform/api/callback/)   
-  If the transformed dataset fit into memory, you can obtains the records from a user defined function. This is usually not recommanded, use the Sync API instead. It is implemented in the same function as the stream API. It is easy and handlers can be written asynchronously.
+  If the transformed dataset fit into memory, you can obtains the records from a user defined function. This is usually not recommended, use the Sync API instead. It is implemented in the same function as the stream API. It is easy and handlers can be written asynchronously.
 * [Stream + callback API](/transform/api/mixed/)  
   The stream and callback APIs can be combined toguether if you need to.
 
-## Additionnal information
+## Additional information
 
 Both modules target ECMAScript Edition 6 (ES6 or ES2015), Node.js version 7.6 and above. For older version of JavaScript, every module is transpiled into ECMAScript Edition 5 (ES5) inside the folder "lib/es5". The ES5 modules share the exact same API with their ES6 counterpart. For example, the `sync` module compatible with ES5 is located available using `require('stream-transform/lib/es5/sync')`.
 

--- a/src/md/transform/distributions.md
+++ b/src/md/transform/distributions.md
@@ -18,7 +18,7 @@ sort: 2
 
 # Available distributions
 
-The library is packaged into multiple distributions depending on your Node.js version, you browser environnement and wether you are using ECMAScript modules (ESM), CommonJS or vanilla JavaScript with support for older browser.
+The library is packaged into multiple distributions depending on your Node.js version, your browser environment and whether you are using ECMAScript modules (ESM), CommonJS or vanilla JavaScript with support for older browser.
 
 - [Node.js ECMAScript modules (ESM)](/transform/distributions/nodejs_esm/)
 - [Node.js CommonJS (CJS)](/transform/distributions/nodejs_cjs/)

--- a/src/pages/convert.js
+++ b/src/pages/convert.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react'
 import Layout from '../layout'
 import Convert from '../components/Convert'
 
-const Convertor = () => (
+const Converter = () => (
   <Layout
     page={{
       title: 'Node.js CSV demo',
@@ -23,4 +23,4 @@ const Convertor = () => (
   </Layout>
 )
 
-export default Convertor
+export default Converter

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -264,7 +264,7 @@ const Index = () => (
       <div>
         <h1>
           <Link to="/convert/">
-            <span>CSV & JSON</span> <span>convertor tool</span>
+            <span>CSV & JSON</span> <span>converter tool</span>
           </Link>
         </h1>
         <p>
@@ -273,7 +273,7 @@ const Index = () => (
           our packages and to test the various options interactively.
         </p>
       </div>
-      <img src={convert_icon} alt="Convertor tool" />
+      <img src={convert_icon} alt="Converter tool" />
     </section>
     <section css={styles.blog}>
       <h1>Latest news</h1>
@@ -294,7 +294,7 @@ const Index = () => (
         <p>
           Version 5.5.0 of csv-parse include the new [`comment_no_infix`
           option](/parse/options/comment_no_infix/). When activate, comments may
-          only start at the begining of a line.
+          only start at the beginning of a line.
         </p>
       </article>
       <article>


### PR DESCRIPTION
- Fix documentation typos across parse, stringify, generate, transform, and project pages
- Standardize wording such as `recommended`, `compatibility`, `environment`, `whether`, and `additional`
- Rename user-facing `Convertor` wording to the more common `Converter`