### PR TITLE
chore(ci): update Node.js version to 24.x and upgrade action versions

### DIFF
--- a/.github/workflows/ci.js.yml
+++ b/.github/workflows/ci.js.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [24.x]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci


### PR DESCRIPTION
## Summary

- Update the CI workflow to run the `www` job on Node.js 24
- Update GitHub Actions dependencies to Node.js 24-compatible versions:
  - `actions/checkout` from `v3` to `v6`
  - `actions/setup-node` from `v3` to `v6`

## Motivation

GitHub Actions now warns that JavaScript actions running on Node.js 20 are deprecated and will be forced to Node.js 24 by default starting June 2, 2026. The `www` job was also still running against Node.js 18.

This updates the workflow proactively so the CI job runs on Node.js 24 and avoids the Node.js 20 action runtime deprecation warning.