### PR TITLE
feat(gatsby): open external links in a new tab with noopener

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,2 +1,34 @@
 
 import 'react-tooltip/dist/react-tooltip.css'
+
+const siteOrigins = ['https://csv.js.org']
+
+const isExternalHttpLink = (href) => {
+  try {
+    const url = new URL(href, window.location.href)
+    const origins = [window.location.origin, ...siteOrigins]
+    return ['http:', 'https:'].includes(url.protocol) && !origins.includes(url.origin)
+  } catch (e) {
+    return false
+  }
+}
+
+const addNoopener = (anchor) => {
+  const rel = new Set((anchor.getAttribute('rel') || '').split(/\s+/).filter(Boolean))
+  rel.add('noopener')
+  rel.add('noreferrer')
+  anchor.setAttribute('rel', Array.from(rel).join(' '))
+}
+
+const openExternalLinksInNewTab = () => {
+  document.querySelectorAll('a[href]').forEach((anchor) => {
+    if (!isExternalHttpLink(anchor.href)) {
+      return
+    }
+    anchor.setAttribute('target', '_blank')
+    addNoopener(anchor)
+  })
+}
+
+export const onInitialClientRender = openExternalLinksInNewTab
+export const onRouteUpdate = openExternalLinksInNewTab

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -16,7 +16,6 @@ const isExternalHttpLink = (href) => {
 const addNoopener = (anchor) => {
   const rel = new Set((anchor.getAttribute('rel') || '').split(/\s+/).filter(Boolean))
   rel.add('noopener')
-  rel.add('noreferrer')
   anchor.setAttribute('rel', Array.from(rel).join(' '))
 }
 


### PR DESCRIPTION
- Open external links in a new browser tab
- Add `rel="noopener"` to external links for safer `_blank` navigation
- Keep internal links, hash links, and links to `csv.js.org` opening in the same tab